### PR TITLE
Bump revisions of openssl for CI

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -18,10 +18,16 @@ jobs:
             link: https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz
           - version: 1.1.0l
             link: https://www.openssl.org/source/old/1.1.0/openssl-1.1.0l.tar.gz
+          # TODO: remove this one when no longer required
           - version: 1.1.1o
             link: https://www.openssl.org/source/openssl-1.1.1o.tar.gz
+          - version: 1.1.1w
+            link: https://www.openssl.org/source/openssl-1.1.1w.tar.gz
+          # TODO: remove this one when no longer required
           - version: 3.0.3
             link: https://www.openssl.org/source/openssl-3.0.3.tar.gz
+          - version: 3.0.17
+            link: https://www.openssl.org/source/openssl-3.0.17.tar.gz
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -67,6 +73,10 @@ jobs:
           - version: 1.1.1o
             lib-dir: lib
           - version: 3.0.3
+            lib-dir: lib64
+          - version: 1.1.1w
+            lib-dir: lib
+          - version: 3.0.17
             lib-dir: lib64
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
These should be backwards compatible updates.