### PR TITLE
TLS client and server version flexibility

### DIFF
--- a/tests/tls.d
+++ b/tests/tls.d
@@ -258,28 +258,46 @@ void testConn(TLSVersion cli_version, TLSVersion srv_version, bool expect_succes
 void testVersion()
 {
 	testConn(TLSVersion.ssl3, TLSVersion.any, false);
-	testConn(TLSVersion.ssl3, TLSVersion.ssl3, false);
+	testConn(TLSVersion.ssl3, TLSVersion.ssl3, true);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_2, false);
-
+	testConn(TLSVersion.ssl3, TLSVersion.tls1_3, false);
+	
+	testConn(TLSVersion.tls1, TLSVersion.any, false);
 	testConn(TLSVersion.tls1, TLSVersion.ssl3, false);
-	testConn(TLSVersion.tls1, TLSVersion.tls1_1, false);
-	testConn(TLSVersion.tls1, TLSVersion.tls1_2, false);
+	testConn(TLSVersion.tls1, TLSVersion.tls1, true);
+	testConn(TLSVersion.tls1, TLSVersion.tls1_1, true);
+	testConn(TLSVersion.tls1, TLSVersion.tls1_2, true);
+	testConn(TLSVersion.tls1, TLSVersion.tls1_3, true);
 
+	testConn(TLSVersion.tls1_1, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_1, TLSVersion.ssl3, false);
-	testConn(TLSVersion.tls1_1, TLSVersion.tls1, false);
-	testConn(TLSVersion.tls1_1, TLSVersion.tls1_2, false);
+	testConn(TLSVersion.tls1_1, TLSVersion.tls1, true);
+	testConn(TLSVersion.tls1_1, TLSVersion.tls1_1, true);
+	testConn(TLSVersion.tls1_1, TLSVersion.tls1_2, true);
+	testConn(TLSVersion.tls1_1, TLSVersion.tls1_3, true);
 
 	testConn(TLSVersion.tls1_2, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.ssl3, false);
-	testConn(TLSVersion.tls1_2, TLSVersion.tls1, false);
-	testConn(TLSVersion.tls1_2, TLSVersion.tls1_1, false);
+	testConn(TLSVersion.tls1_2, TLSVersion.tls1, true);
+	testConn(TLSVersion.tls1_2, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_2, true);
+	testConn(TLSVersion.tls1_2, TLSVersion.tls1_3, true);
+
+	testConn(TLSVersion.tls1_3, TLSVersion.any, true);
+	testConn(TLSVersion.tls1_3, TLSVersion.ssl3, false);
+	testConn(TLSVersion.tls1_3, TLSVersion.tls1, true);
+	testConn(TLSVersion.tls1_3, TLSVersion.tls1_1, true);
+	testConn(TLSVersion.tls1_3, TLSVersion.tls1_2, true);
+	testConn(TLSVersion.tls1_3, TLSVersion.tls1_3, true);
 
 	testConn(TLSVersion.any, TLSVersion.any, true);
 	testConn(TLSVersion.any, TLSVersion.ssl3, false);
+	testConn(TLSVersion.any, TLSVersion.tls1, false);
+	testConn(TLSVersion.any, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_2, true);
+	testConn(TLSVersion.any, TLSVersion.tls1_3, true);	
 }
 
 void main()

--- a/tests/tls.d
+++ b/tests/tls.d
@@ -16,6 +16,8 @@ import vibe.stream.tls;
 import vibe.stream.taskpipe;
 import std.encoding : sanitize;
 
+import deimos.openssl.ssl;
+
 TLSContext createContext(TLSContextKind kind, string cert, string key, string trust, TLSPeerValidationMode mode)
 {
 	auto ctx = createTLSContext(kind);
@@ -262,42 +264,49 @@ void testVersion()
 	testConn(TLSVersion.ssl3, TLSVersion.tls1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_2, false);
-	testConn(TLSVersion.ssl3, TLSVersion.tls1_3, false);
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+		testConn(TLSVersion.ssl3, TLSVersion.tls1_3, false);
 
 	testConn(TLSVersion.tls1, TLSVersion.any, true);
 	testConn(TLSVersion.tls1, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1, TLSVersion.tls1_2, true);
-	testConn(TLSVersion.tls1, TLSVersion.tls1_3, true);
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+		testConn(TLSVersion.tls1, TLSVersion.tls1_3, true);
 
 	testConn(TLSVersion.tls1_1, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_1, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1_1, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1_1, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_1, TLSVersion.tls1_2, true);
-	testConn(TLSVersion.tls1_1, TLSVersion.tls1_3, true);
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+		testConn(TLSVersion.tls1_1, TLSVersion.tls1_3, true);
 
 	testConn(TLSVersion.tls1_2, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_2, true);
-	testConn(TLSVersion.tls1_2, TLSVersion.tls1_3, true);
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))  
+		testConn(TLSVersion.tls1_2, TLSVersion.tls1_3, true);
 
+static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0)) {  
 	testConn(TLSVersion.tls1_3, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_3, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1_3, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1_3, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_3, TLSVersion.tls1_2, true);
 	testConn(TLSVersion.tls1_3, TLSVersion.tls1_3, true);
+}
 
 	testConn(TLSVersion.any, TLSVersion.any, true);
 	testConn(TLSVersion.any, TLSVersion.ssl3, false);
 	testConn(TLSVersion.any, TLSVersion.tls1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_2, true);
-	testConn(TLSVersion.any, TLSVersion.tls1_3, true);
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+		testConn(TLSVersion.any, TLSVersion.tls1_3, true);
 }
 
 void main()

--- a/tests/tls.d
+++ b/tests/tls.d
@@ -272,7 +272,7 @@ void testVersion()
 	testConn(TLSVersion.tls1, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1, TLSVersion.tls1_2, true);
-	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))
 		testConn(TLSVersion.tls1, TLSVersion.tls1_3, true);
 
 	testConn(TLSVersion.tls1_1, TLSVersion.any, true);
@@ -280,7 +280,7 @@ void testVersion()
 	testConn(TLSVersion.tls1_1, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1_1, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_1, TLSVersion.tls1_2, true);
-	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))
 		testConn(TLSVersion.tls1_1, TLSVersion.tls1_3, true);
 
 	testConn(TLSVersion.tls1_2, TLSVersion.any, true);
@@ -288,10 +288,10 @@ void testVersion()
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_2, true);
-	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))  
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))  
 		testConn(TLSVersion.tls1_2, TLSVersion.tls1_3, true);
 
-static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0)) {  
+static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1)) {  
 	testConn(TLSVersion.tls1_3, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_3, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1_3, TLSVersion.tls1, true);
@@ -305,7 +305,7 @@ static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0)) {
 	testConn(TLSVersion.any, TLSVersion.tls1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_2, true);
-	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))
 		testConn(TLSVersion.any, TLSVersion.tls1_3, true);
 }
 

--- a/tests/tls.d
+++ b/tests/tls.d
@@ -258,13 +258,13 @@ void testConn(TLSVersion cli_version, TLSVersion srv_version, bool expect_succes
 void testVersion()
 {
 	testConn(TLSVersion.ssl3, TLSVersion.any, false);
-	testConn(TLSVersion.ssl3, TLSVersion.ssl3, true);
+	testConn(TLSVersion.ssl3, TLSVersion.ssl3, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_2, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_3, false);
-	
-	testConn(TLSVersion.tls1, TLSVersion.any, false);
+
+	testConn(TLSVersion.tls1, TLSVersion.any, true);
 	testConn(TLSVersion.tls1, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1, TLSVersion.tls1_1, true);
@@ -294,10 +294,10 @@ void testVersion()
 
 	testConn(TLSVersion.any, TLSVersion.any, true);
 	testConn(TLSVersion.any, TLSVersion.ssl3, false);
-	testConn(TLSVersion.any, TLSVersion.tls1, false);
+	testConn(TLSVersion.any, TLSVersion.tls1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.any, TLSVersion.tls1_2, true);
-	testConn(TLSVersion.any, TLSVersion.tls1_3, true);	
+	testConn(TLSVersion.any, TLSVersion.tls1_3, true);
 }
 
 void main()

--- a/tests/tls.d
+++ b/tests/tls.d
@@ -264,7 +264,7 @@ void testVersion()
 	testConn(TLSVersion.ssl3, TLSVersion.tls1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_1, false);
 	testConn(TLSVersion.ssl3, TLSVersion.tls1_2, false);
-	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 0))
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))
 		testConn(TLSVersion.ssl3, TLSVersion.tls1_3, false);
 
 	testConn(TLSVersion.tls1, TLSVersion.any, true);

--- a/tests/tls.d
+++ b/tests/tls.d
@@ -288,10 +288,10 @@ void testVersion()
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_1, true);
 	testConn(TLSVersion.tls1_2, TLSVersion.tls1_2, true);
-	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))  
+	static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1))
 		testConn(TLSVersion.tls1_2, TLSVersion.tls1_3, true);
 
-static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1)) {  
+static if (OPENSSL_VERSION_AT_LEAST(1, 1, 1)) {
 	testConn(TLSVersion.tls1_3, TLSVersion.any, true);
 	testConn(TLSVersion.tls1_3, TLSVersion.ssl3, false);
 	testConn(TLSVersion.tls1_3, TLSVersion.tls1, true);

--- a/tls/vibe/stream/openssl.d
+++ b/tls/vibe/stream/openssl.d
@@ -727,9 +727,9 @@ final class OpenSSLContext : TLSContext {
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1; break;
 					case TLSVersion.ssl3: throw new Exception("SSLv3 is not supported anymore");
-					case TLSVersion.tls1: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1_2; maxver = TLS1_VERSION; break;
-					case TLSVersion.tls1_1: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = TLS1_1_VERSION; maxver = TLS1_1_VERSION; break;
-					case TLSVersion.tls1_2: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; maxver = TLS1_2_VERSION; break;
+					case TLSVersion.tls1: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3; minver = TLS1_VERSION; break;
+					case TLSVersion.tls1_1: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1; minver = TLS1_1_VERSION; break;
+					case TLSVersion.tls1_2: method = SSLv23_client_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; break;
 					case TLSVersion.tls1_3:
 						static if (OPENSSL_VERSION_BEFORE(1, 1, 1)) {
 							 throw new Exception("OpenSSL "~OpenSSLVersion.text~" does not support TLSv1.3");
@@ -747,9 +747,9 @@ final class OpenSSLContext : TLSContext {
 				final switch (ver) {
 					case TLSVersion.any: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1; break;
 					case TLSVersion.ssl3: throw new Exception("SSLv3 is not supported anymore");
-					case TLSVersion.tls1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1_1|SSL_OP_NO_TLSv1_2; maxver = TLS1_VERSION; break;
-					case TLSVersion.tls1_1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_2; minver = TLS1_1_VERSION; maxver = TLS1_1_VERSION; break;
-					case TLSVersion.tls1_2: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; maxver = TLS1_2_VERSION; break;
+					case TLSVersion.tls1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3; minver = TLS1_VERSION; break;
+					case TLSVersion.tls1_1: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1; minver = TLS1_1_VERSION; break;
+					case TLSVersion.tls1_2: method = SSLv23_server_method(); veroptions |= SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1; minver = TLS1_2_VERSION; break;
 					case TLSVersion.tls1_3:
 						static if (OPENSSL_VERSION_BEFORE(1, 1, 1)) {
 							throw new Exception("OpenSSL "~OpenSSLVersion.text~" does not support TLSv1.3");

--- a/tls/vibe/stream/tls.d
+++ b/tls/vibe/stream/tls.d
@@ -335,7 +335,7 @@ enum TLSContextKind {
 }
 
 enum TLSVersion {
-	any, /// Accept TLSv1.0 and greater
+	any, /// Accept TLSv1.1 and greater
 	ssl3, /// Accept only SSLv3 (not supported anymore)
 	tls1, /// Accept TLSv1.0 or above
 	tls1_1, /// Accept TLSv1.1 or above

--- a/tls/vibe/stream/tls.d
+++ b/tls/vibe/stream/tls.d
@@ -337,9 +337,9 @@ enum TLSContextKind {
 enum TLSVersion {
 	any, /// Accept TLSv1.0 and greater
 	ssl3, /// Accept only SSLv3 (not supported anymore)
-	tls1, /// Accept only TLSv1.0
-	tls1_1, /// Accept only TLSv1.1
-	tls1_2, /// Accept only TLSv1.2
+	tls1, /// Accept TLSv1.0 or above
+	tls1_1, /// Accept TLSv1.1 or above
+	tls1_2, /// Accept TLSv1.2 or above
 	tls1_3, /// Accept only TLSv1.3
 	dtls1, /// Use DTLSv1.0
 


### PR DESCRIPTION
Update openssl.d TLS version: Allow TLS clients and servers to use selected TLS version (i.e. TLS 1.2) and above (i.e. TLS 1.3). Previously they could only use exactly the selected version.

Update tls.d TLS version enum comments: Changed comments related to TLSVersion enum to make it clear, that the clients and servers use the selected TLS version or a version above.

Correct tls.d TLSVersion.any comment: TLSVersion.any requires TLS 1.1 or higher as defined in openssl.d.

Update tls.d testVersion(): Changed and expanded testVersion() function to match the changes to TLSVersion usage.

We could test more precisely in tls.d testVersion() if we - after call to createTLSStream - could get the actual used TLS version for a connection. This would enable us to make sure, that the connection uses a TLS version equal to or above the requested TLS versions for client and for server. Writing such a getter function is beyond my skill level. If such one existed, I could do the update to testVersion().
