### PR TITLE
Let ConnectionProxyStream.close() give up stream ownership

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-14]
+                os: [ubuntu-latest, windows-latest]
                 dc: [dmd-latest, ldc-latest]
                 arch: [x86_64]
                 include:
                   - { os: windows-latest, dc: dmd-2.100.2, arch: x86_64 }
                   - { os: windows-latest, dc: dmd-2.100.2, arch: x86_mscoff }
                   - { os: windows-latest, dc: ldc-1.30.0, arch: x86_64 }
+                  - { os: macOS-14, dc: ldc-latest, arch: aarch64 }
 
         runs-on: ${{matrix.os}}
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-latest, windows-latest, macOS-13]
+                os: [ubuntu-latest, windows-latest, macOS-14]
                 dc: [dmd-latest, ldc-latest]
                 arch: [x86_64]
                 include:
@@ -30,7 +30,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Install D compiler
-              uses: dlang-community/setup-dlang@v1
+              uses: dlang-community/setup-dlang@v2
               with:
                   compiler: ${{matrix.dc}}
 

--- a/source/vibe/stream/wrapper.d
+++ b/source/vibe/stream/wrapper.d
@@ -108,7 +108,11 @@ class ProxyStream : Stream {
 
 	void flush() { m_output.flush(); }
 
-	void finalize() { m_output.finalize(); }
+	void finalize()
+	{
+		m_output.finalize();
+		m_output = InterfaceProxy!OutputStream.init;
+	}
 }
 
 
@@ -156,6 +160,12 @@ class ConnectionProxyStream : ConnectionStream {
 		return m_connection.connected;
 	}
 
+	/** Closes the underlying connection and gives up ownership of the wrapped
+		streams.
+
+		Note that the `.underlying` property will return a null stream after
+		calling `close()`.
+	*/
 	void close()
 	{
 		if (!m_connection)
@@ -163,6 +173,11 @@ class ConnectionProxyStream : ConnectionStream {
 
 		if (m_connection.connected) finalize();
 		m_connection.close();
+
+		m_connection = InterfaceProxy!ConnectionStream.init;
+		m_output = InterfaceProxy!OutputStream.init;
+		m_input = InterfaceProxy!InputStream.init;
+		m_underlying = InterfaceProxy!Stream.init;
 	}
 
 	bool waitForData(Duration timeout = 0.seconds)
@@ -205,7 +220,11 @@ class ConnectionProxyStream : ConnectionStream {
 
 	void flush() { m_output.flush(); }
 
-	void finalize() { m_output.finalize(); }
+	void finalize()
+	{
+		m_output.finalize();
+		m_output = InterfaceProxy!OutputStream.init;
+	}
 }
 
 

--- a/source/vibe/stream/wrapper.d
+++ b/source/vibe/stream/wrapper.d
@@ -92,24 +92,38 @@ class ProxyStream : Stream {
 
 	@property bool dataAvailableForRead() { return m_input ? m_input.dataAvailableForRead : false; }
 
-	const(ubyte)[] peek() { return m_input.peek(); }
+	const(ubyte)[] peek() { return m_input ? m_input.peek() : null; }
 
-	size_t read(scope ubyte[] dst, IOMode mode) { return m_input.read(dst, mode); }
+	size_t read(scope ubyte[] dst, IOMode mode)
+	{
+		if (!m_input) throw new Exception("Attempt to read from closed stream");
+		return m_input.read(dst, mode);
+	}
 
 	alias read = Stream.read;
 
 	static if (is(typeof(.OutputStream.outputStreamVersion)) && .OutputStream.outputStreamVersion > 1) {
-		override size_t write(scope const(ubyte)[] bytes, IOMode mode) { return m_output.write(bytes, mode); }
+		override size_t write(scope const(ubyte)[] bytes, IOMode mode)
+		{
+			if (!m_output) throw new Exception("Attempt to write to closed stream");
+			return m_output.write(bytes, mode);
+		}
 	} else {
-		override size_t write(in ubyte[] bytes, IOMode mode) { return m_output.write(bytes, mode); }
+		override size_t write(in ubyte[] bytes, IOMode mode)
+		{
+			if (!m_output) throw new Exception("Attempt to write to closed stream");
+			return m_output.write(bytes, mode);
+		}
 	}
 
 	alias write = Stream.write;
 
-	void flush() { m_output.flush(); }
+	void flush() { if (m_output) m_output.flush(); }
 
 	void finalize()
 	{
+		if (!m_output) return;
+
 		m_output.finalize();
 		m_output = InterfaceProxy!OutputStream.init;
 	}
@@ -204,24 +218,38 @@ class ConnectionProxyStream : ConnectionStream {
 
 	@property bool dataAvailableForRead() { return m_input ? m_input.dataAvailableForRead : false; }
 
-	const(ubyte)[] peek() { return m_input.peek(); }
+	const(ubyte)[] peek() { return m_input ? m_input.peek() : null; }
 
-	size_t read(scope ubyte[] dst, IOMode mode) { return m_input.read(dst, mode); }
+	size_t read(scope ubyte[] dst, IOMode mode)
+	{
+		if (!m_input) throw new Exception("Attempt to read from closed stream");
+		return m_input.read(dst, mode);
+	}
 
 	alias read = ConnectionStream.read;
 
 	static if (is(typeof(.OutputStream.outputStreamVersion)) && .OutputStream.outputStreamVersion > 1) {
-		size_t write(scope const(ubyte)[] bytes, IOMode mode) { return m_output.write(bytes, mode); }
+		size_t write(scope const(ubyte)[] bytes, IOMode mode)
+		{
+			if (!m_output) throw new Exception("Attempt to write to closed stream");
+			return m_output.write(bytes, mode);
+		}
 	} else {
-		size_t write(in ubyte[] bytes, IOMode mode) { return m_output.write(bytes, mode); }
+		size_t write(in ubyte[] bytes, IOMode mode)
+		{
+			if (!m_output) throw new Exception("Attempt to write to closed stream");
+			return m_output.write(bytes, mode);
+		}
 	}
 
 	alias write = ConnectionStream.write;
 
-	void flush() { m_output.flush(); }
+	void flush() { if (m_output) m_output.flush(); }
 
 	void finalize()
 	{
+		if (!m_output) return;
+
 		m_output.finalize();
 		m_output = InterfaceProxy!OutputStream.init;
 	}


### PR DESCRIPTION
Ensures that underlying sockets or file handles can get closed after a call to close().

Closes #14.